### PR TITLE
feat(avatars): optimize avatar pipeline with WebP conversion, cache-b…

### DIFF
--- a/components/community/CommunitySection.tsx
+++ b/components/community/CommunitySection.tsx
@@ -39,7 +39,7 @@ const CommunitySection: React.FC<CommunitySeccionProps> = ({ profilePictures = [
       id="comunidad"
       className="bg-card/90 border-border/20 container mx-auto mb-10 rounded-lg border p-8 px-4 text-center shadow-lg backdrop-blur-sm transition-all duration-300 dark:shadow-2xl dark:shadow-black/25"
     >
-      <h1 className="text-primary mb-6 text-2xl font-extrabold">Nuestra Comunidad</h1>
+      <h1 className="text-primary mb-6 text-3xl font-extrabold">Nuestra Comunidad</h1>
 
       <div className="bg-muted/30 dark:bg-muted/10 border-border/50 dark:border-border/30 relative h-96 w-full overflow-hidden rounded-lg border-2 transition-colors duration-300">
         {/* Overlay de carga mejorado */}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,4 +1,5 @@
-// lib/auth.ts
+import 'server-only';
+
 import NextAuth from 'next-auth';
 import { PrismaAdapter } from '@auth/prisma-adapter';
 import Google from 'next-auth/providers/google';

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,12 +1,9 @@
 // next.config.ts
 import type { NextConfig } from 'next';
 
-const isProd = process.env.NODE_ENV === 'production';
-
 function makeCSP() {
   return [
     "default-src 'self'",
-    // Permitir unsafe-eval para NextAuth.js en ambos entornos
     "script-src 'self' 'unsafe-eval' 'unsafe-inline'",
     "style-src 'self' 'unsafe-inline'",
     "img-src 'self' data: blob: https:",
@@ -15,9 +12,7 @@ function makeCSP() {
     "frame-ancestors 'none'",
     "base-uri 'self'",
     "form-action 'self'",
-  ]
-    .filter(Boolean)
-    .join('; ');
+  ].join('; ');
 }
 
 const nextConfig: NextConfig = {
@@ -25,9 +20,16 @@ const nextConfig: NextConfig = {
     remotePatterns: [
       { protocol: 'https', hostname: 'avatars.githubusercontent.com' },
       { protocol: 'https', hostname: 'lh3.googleusercontent.com' },
+      {
+        protocol: 'https',
+        hostname: 'covrlthxywrlxpogrlef.supabase.co',
+        pathname: '/storage/v1/object/public/avatars/**',
+      },
     ],
     formats: ['image/webp', 'image/avif'],
-    minimumCacheTTL: 86400,
+    minimumCacheTTL: 3600,             // ↑ cache del optimizador (seguro con versión)
+    deviceSizes: [360, 414, 640, 768, 1024],
+    imageSizes: [32, 48, 64, 96, 160, 256],
   },
   async headers() {
     const csp = makeCSP();

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "--silent next dev",
+    "dev": "next dev",
     "build": "next build",
     "start": "next start",
     "format": "prettier --write .",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,16 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
-    "types": ["node"],
+    "types": [
+      "node"
+    ],
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
@@ -21,17 +27,43 @@
       }
     ],
     "paths": {
-      "@/*": ["./*"],
-      "@/types": ["./types"],
-      "@/constants": ["./constants"],
-      "@/utils": ["./utils"],
-      "@/components": ["./components"],
-      "@/lib": ["./lib"],
-      "@/hooks": ["./hooks"],
-      "@/actions": ["./actions"],
-      "@/services": ["./services"]
+      "@/*": [
+        "./*"
+      ],
+      "@/types": [
+        "./types"
+      ],
+      "@/constants": [
+        "./constants"
+      ],
+      "@/utils": [
+        "./utils"
+      ],
+      "@/components": [
+        "./components"
+      ],
+      "@/lib": [
+        "./lib"
+      ],
+      "@/hooks": [
+        "./hooks"
+      ],
+      "@/actions": [
+        "./actions"
+      ],
+      "@/services": [
+        "./services"
+      ]
     }
   },
-  "include": ["**/*.ts", "**/*.tsx", "next-env.d.ts", "types/**/*.ts", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    "next-env.d.ts",
+    "types/**/*.ts",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
…usting, and cleanup

- Store avatar variants in Supabase as `.webp` with correct Content-Type (`image/webp`)
- Introduce SHA-1 hashing to detect upstream image changes (e.g. GitHub/Google avatars)
  - Only re-upload if the hash differs (no redundant copies in storage)
  - Persist hash in `users/<id>/hash.txt` for quick comparisons
- Add cache-busting via `?v=<hash>` query param, ensuring updated avatars are reflected immediately while keeping object URLs immutable for CDN/browser caching
- Update `/api/avatars/[id]/[size]` to return a 302 redirect with short-lived caching headers (`max-age=60, stale-while-revalidate=600`) → object itself remains strongly cached
- Fix ESLint warnings by removing `any` types in hash storage helpers
- Configure Next.js to serve modern formats (`image/avif`, `image/webp`) in `next.config.js`
- Remove unnecessary `components/community/index.ts` barrel file and update imports to explicit paths
- Improve developer clarity and reliability in avatar loading, ensuring all served images are WebP-optimized and updates are reflected without bloating storage